### PR TITLE
Make table output nicer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,60 @@
+mod table;
+
 use ns2_stat::{NS2Stats, User, Map};
+use table::Alignment;
+
+struct UserRow {
+    name: String,
+    kills: u32,
+    deaths: u32,
+    kd: f32,
+}
+
+struct MapRow {
+    map: String,
+    marine_wr: f32,
+    total_games: u32,
+}
 
 fn main() -> std::io::Result<()> {
     let stats = NS2Stats::from_dir("test_data")?;
 
-    let mut users = stats.users.into_iter().collect::<Vec<_>>();
-    users.sort_by_key(|(_, user)| ((user.kills as f32 / user.deaths as f32) * 100f32) as u32);
-    println!("NAME\t\tKILLS\tDEATHS\tKD");
-    for (name, User { kills, deaths, .. }) in users.into_iter().rev() {
+    let mut users = stats.users.into_iter().filter_map(|(name, User { kills, deaths, .. })| {
         if kills <= 50 || deaths <= 50 {
-            continue;
+            None
+        } else {
+            let kd = kills as f32 / deaths as f32;
+            Some(UserRow { name, kills, deaths, kd })
         }
-        let kd = kills as f32 / deaths as f32;
-        println!("{name}\t{kills}\t{deaths}\t{kd:.2}");
-    }
+    }).collect::<Vec<_>>();
+    users.sort_by_key(|user| -(user.kd * 100f32) as i32);
+    table::print_table(
+        ["NAME", "KILLS", "DEATHS", "KD"],
+        [Alignment::Left, Alignment::Right, Alignment::Right, Alignment::Right],
+        users,
+        |UserRow { name, kills, deaths, kd }| row!["{name}", "{kills}", "{deaths}", "{kd:.2}"],
+    );
 
-    println!("\n\n\n");
+    println!("\n\n");
 
     let marine_wr = stats.marine_wins as f32 * 100f32 / stats.total_games as f32;
     println!("MARINE WR: {marine_wr:.2}%");
 
-    println!("MAP\t\tMARINE WR\tTOTAL ROUNDS");
-    let mut kvp = stats.maps.into_iter().collect::<Vec<_>>();
-    kvp.sort_by_key(|(_, Map { total_games: r, marine_wins: w })| ((*w as f32 / *r as f32) * 100f32) as u32);
-    for (map, Map { total_games, marine_wins }) in kvp.into_iter().rev() {
+    println!();
+
+    let mut kvp = stats.maps.into_iter().map(|(map, Map { total_games, marine_wins, .. })| {
         let marine_wr = marine_wins as f32 * 100f32 / total_games as f32;
-        println!("{map}\t{marine_wr:.2}%\t\t{total_games} rounds");
-    }
+        MapRow { map, marine_wr, total_games }
+    }).collect::<Vec<_>>();
+    kvp.sort_by_key(|map| -map.marine_wr as i32);
+    table::print_table(
+        ["MAP", "MARINE WR", "TOTAL ROUNDS"],
+        [Alignment::Left, Alignment::Right, Alignment::Right],
+        kvp,
+        |MapRow { map, marine_wr, total_games }| row!["{map}", "{marine_wr:.2}%", "{total_games} rounds"],
+    );
+
+    println!();
 
     let total_games = stats.total_games;
     println!("TOTAL GAMES: {total_games}");

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,0 +1,42 @@
+#[macro_export]
+macro_rules! row {
+    ($($e:literal),*) => {
+        [$(format!($e)),*]
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Alignment {
+    Left,
+    Center,
+    Right,
+}
+
+pub fn print_table<T, const N: usize>(titles: [&str; N], alignments: [Alignment; N], table: Vec<T>, formatter: impl Fn(T) -> [String; N]) {
+    let mut lengths = [0; N]; // `lengths[i]` is the length of the ith column
+    let rows = table.into_iter().map(formatter).collect::<Vec<_>>();
+    for i in 0..N {
+        lengths[i] = std::cmp::max(
+            titles[i].len(),
+            rows.iter().map(|row| row[i].len()).max().unwrap_or(0)
+        );
+    }
+
+    for i in 0..N {
+        print!("{:width$}    ", titles[i], width = lengths[i]);
+    }
+    println!();
+    for row in rows {
+        for i in 0..N {
+            let content = &row[i];
+            let alignment = alignments[i];
+            let len = lengths[i];
+            match alignment {
+                Alignment::Left => print!("{:<width$}    ", content, width = len),
+                Alignment::Center => print!("{:^width$}    ", content, width = len),
+                Alignment::Right => print!("{:>width$}    ", content, width = len),
+            }
+        }
+        println!();
+    }
+}


### PR DESCRIPTION
Now all columns of the table output are properly aligned. The alignment (left, center, right) can be chosen via the `table::Alignment` enum. Also refactored the vector creation a bit.